### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/comics/utils/comicimporter.py
+++ b/comics/utils/comicimporter.py
@@ -5,7 +5,7 @@ from comics.models import Arc, Character, Creator, Team, Publisher, Series, Issu
 from .comicfilehandler import ComicFileHandler
 from . import fnameparser, utils
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 class ComicImporter(object):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,10 @@ Django==1.10.1
 django-multiselectfield==0.1.7
 django-solo==1.1.2
 django-widget-tweaks==1.4.1
-fuzzywuzzy==0.15.1
 kombu==3.0.35
 Pillow>=3.5,<=4.0
 PyPDF2==1.26.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.2.1
 rarfile==2.8
 requests==2.11.1
 requests-cache==0.4.12


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.